### PR TITLE
Typo fix in "Modify biography" (plus "mandatory"...?)

### DIFF
--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -20,7 +20,7 @@ en:
         data: Data
         display_name: Display alias
         email: Mail
-        header: Backaground photo
+        header: Background photo
         locale: Localization
         locked: Lock account
         new_password: Adjust password
@@ -43,5 +43,5 @@ en:
     'no': 'No'
     required:
       mark: "*"
-      text: madatory
+      text: mandatory
     'yes': 'Okay'


### PR DESCRIPTION
"Backaground" -> "background" (see #5)
"madatory" -> "mandatory"
I don't know any location with display of "madatory," but it's not right.