### PR TITLE
Add Oulipo::Formatt*r

### DIFF
--- a/app/lib/oulipo/formatter.rb
+++ b/app/lib/oulipo/formatter.rb
@@ -4,7 +4,7 @@ require 'nokogiri'
 
 class Oulipo::Formatter < Formatter
 
-  FIFTH_GLYPH_REGEX = /[eèéêëēėę3ǝɛ]/i
+  FIFTH_GLYPH_REGEX = /[eèéêëēėęǝɛ]/i
 
   def format(status)
     html = super

--- a/app/lib/oulipo/formatter.rb
+++ b/app/lib/oulipo/formatter.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'nokogiri'
+
+class Oulipo::Formatter < Formatter
+
+  FIFTH_GLYPH_REGEX = /[eèéêëēėę3ǝɛ]/i
+
+  def format(status)
+    html = super
+    fragment = Nokogiri::HTML.fragment(html)
+    fragment.traverse do |node|
+      if node.text?
+        node.content = node.content.gsub(FIFTH_GLYPH_REGEX, '*')
+      end
+    end
+    fragment.serialize.html_safe # rubocop:disable Rails/OutputSafety
+  end
+
+end

--- a/app/views/api/v1/statuses/_show.rabl
+++ b/app/views/api/v1/statuses/_show.rabl
@@ -1,7 +1,7 @@
 attributes :id, :created_at, :in_reply_to_id, :in_reply_to_account_id, :sensitive, :spoiler_text, :visibility
 
 node(:uri)              { |status| TagManager.instance.uri_for(status) }
-node(:content)          { |status| Formatter.instance.format(status) }
+node(:content)          { |status| Oulipo::Formatter.instance.format(status) }
 node(:url)              { |status| TagManager.instance.url_for(status) }
 node(:reblogs_count)    { |status| defined?(@reblogs_counts_map)    ? (@reblogs_counts_map[status.id]    || 0) : status.reblogs_count }
 node(:favourites_count) { |status| defined?(@favourites_counts_map) ? (@favourites_counts_map[status.id] || 0) : status.favourites_count }

--- a/spec/lib/oulipo/formatter_spec.rb
+++ b/spec/lib/oulipo/formatter_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe Oulipo::Formatter do
+
+  let(:account)       { Fabricate(:account, username: 'al') }
+  let(:simple_status)  { Fabricate(:status, text: 'Mice èat chéêsë!', account: account) }
+  let(:link_status)  { Fabricate(:status, text: 'Lovē this Excėllęnt sitǝ: https://example.com', account: account) }
+  let(:mention_status)  { Fabricate(:status, text: 'Hɛy @ecmendenhall@party.personal.pizza', account: account) }
+  let(:remote_status) { Fabricate(:status, text: '<script>alert("Hello")</script> Beep boop', uri: 'beepboop', account: account) }
+
+  describe '#format' do
+    describe 'simple statuses' do
+      subject { Oulipo::Formatter.instance.format(simple_status) }
+
+      it 'blocks that fifth glyph' do
+        expect(subject).to match(
+          '<p>Mic* *at ch**s*!</p>'
+        )
+      end
+    end
+
+    describe 'statuses with links' do
+      subject { Oulipo::Formatter.instance.format(link_status) }
+
+      it 'blocks that fifth glyph' do
+        expect(subject).to match(
+          '<p>Lov* this *xc*ll*nt sit*: <a href="https://example.com" rel="nofollow noopener" target="_blank"><span class="invisible">https://</span><span class="">*xampl*.com</span><span class="invisible"></span></a></p>'
+        )
+      end
+    end
+
+    describe 'statuses with mentions' do
+      subject { Oulipo::Formatter.instance.format(mention_status) }
+
+      it 'blocks that fifth glyph' do
+        expect(subject).to match(
+          '<p>H*y @*cm*nd*nhall@party.p*rsonal.pizza</p>'
+        )
+      end
+    end
+  end
+
+  describe '#reformat' do
+    subject { Oulipo::Formatter.instance.format(remote_status) }
+
+    it 'returns a string' do
+      expect(subject).to be_a String
+    end
+
+    it 'contains plain text' do
+      expect(subject).to match('B\*\*p boop')
+    end
+
+    it 'does not contain scripts' do
+      expect(subject).to_not match('<script>alert("Hello")</script>')
+    end
+  end
+end


### PR DESCRIPTION
Fix for #3 

- Modify `Formatt*r` to block that fifth glyph and variants.
- Swap out `Formatt*r` in `/app/vi*ws/api/v1/status*s/_show`
- Add `FIFTH_GLYPH_R*G*X` to spot invalid glyphs.
- Walk toots with Nokogiri to swap invalid glyphs. (Won't touch links or @'s)

I am not following our norms in all this Ruby...might call it a goal, but not now, I don't think.