### PR TITLE
Automatic trial data

### DIFF
--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -17,7 +17,7 @@ class PostStatusService < BaseService
     text_without_urls= text.gsub(/http.?:\/\/[^\s\\]+/, '')
     text_without_urls= text_without_urls.gsub(/@[^\s\\]+@[^\s\\]+\.[a-z]+/, '')
     raise Mastodon::ValidationError, 'Invalid symbol' if text_without_urls.downcase.include? 'e'
-    raise Mastodon::ValidationError, 'Invalid symbol' if options[:spoiler_text].downcase.include? 'e'
+    raise Mastodon::ValidationError, 'Invalid symbol' if options.fetch(:spoiler_text, '').to_s.downcase.include? 'e'
     status = account.statuses.create!(text: text,
                                       thread: in_reply_to,
                                       sensitive: options[:sensitive],

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -3,20 +3,20 @@ require 'rails_helper'
 RSpec.describe AccountsController, type: :controller do
   render_views
 
-  let(:alice)  { Fabricate(:account, username: 'alice') }
+  let(:mus)  { Fabricate(:account, username: 'mus') }
 
   describe 'GET #show' do
     before do
-      status1 = Status.create!(account: alice, text: 'Hello world')
-      Status.create!(account: alice, text: 'Boop', thread: status1)
-      status3 = Status.create!(account: alice, text: 'Picture!')
-      status3.media_attachments.create!(account: alice, file: fixture_file_upload('files/attachment.jpg', 'image/jpeg'))
-      Status.create!(account: alice, text: 'Mentioning @alice')
+      status1 = Status.create!(account: mus, text: 'Hello world')
+      Status.create!(account: mus, text: 'Boop', thread: status1)
+      status3 = Status.create!(account: mus, text: 'Picture!')
+      status3.media_attachments.create!(account: mus, file: fixture_file_upload('files/attachment.jpg', 'image/jpeg'))
+      Status.create!(account: mus, text: 'Mentioning @mus')
     end
 
     context 'atom' do
       before do
-        get :show, params: { username: alice.username }, format: 'atom'
+        get :show, params: { username: mus.username }, format: 'atom'
       end
 
       it 'returns http success with Atom' do
@@ -26,7 +26,7 @@ RSpec.describe AccountsController, type: :controller do
 
     context 'activitystreams2' do
       before do
-        get :show, params: { username: alice.username }, format: 'activitystreams2'
+        get :show, params: { username: mus.username }, format: 'activitystreams2'
       end
 
       it 'returns http success with Activity Streams 2.0' do
@@ -36,7 +36,7 @@ RSpec.describe AccountsController, type: :controller do
 
     context 'html' do
       before do
-        get :show, params: { username: alice.username }
+        get :show, params: { username: mus.username }
       end
 
       it 'returns http success' do
@@ -47,14 +47,14 @@ RSpec.describe AccountsController, type: :controller do
 
   describe 'GET #followers' do
     it 'returns http success' do
-      get :followers, params: { username: alice.username }
+      get :followers, params: { username: mus.username }
       expect(response).to have_http_status(:success)
     end
   end
 
   describe 'GET #following' do
     it 'returns http success' do
-      get :following, params: { username: alice.username }
+      get :following, params: { username: mus.username }
       expect(response).to have_http_status(:success)
     end
   end

--- a/spec/controllers/api/oembed_controller_spec.rb
+++ b/spec/controllers/api/oembed_controller_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Api::OEmbedController, type: :controller do
-  let(:alice)  { Fabricate(:account, username: 'alice') }
-  let(:status) { Fabricate(:status, text: 'Hello world', account: alice) }
+  let(:mus)  { Fabricate(:account, username: 'mus') }
+  let(:status) { Fabricate(:status, text: 'Hello world', account: mus) }
 
   describe 'GET #show' do
     before do
-      get :show, params: { url: account_stream_entry_url(alice, status.stream_entry) }, format: :json
+      get :show, params: { url: account_stream_entry_url(mus, status.stream_entry) }, format: :json
     end
 
     it 'returns http success' do

--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::AccountsController, type: :controller do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'mus')) }
   let(:token) { double acceptable?: true, resource_owner_id: user.id }
 
   before do
@@ -31,7 +31,7 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
         header = File.read(Rails.root.join('app', 'assets', 'images', 'mastodon-getting-started.png'))
 
         patch :update_credentials, params: {
-          display_name: "Alice Isn't Dead",
+          display_name: "mus Isn't Dad",
           note: "Hi!\n\nToot toot!",
           avatar: "data:image/png;base64,#{Base64.encode64(avatar)}",
           header: "data:image/png;base64,#{Base64.encode64(header)}",
@@ -45,7 +45,7 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
       it 'updates account info' do
         user.account.reload
 
-        expect(user.account.display_name).to eq("Alice Isn't Dead")
+        expect(user.account.display_name).to eq("mus Isn't Dad")
         expect(user.account.note).to eq("Hi!\n\nToot toot!")
         expect(user.account.avatar).to exist
         expect(user.account.header).to exist
@@ -195,11 +195,11 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
 
   describe 'GET #relationships' do
     let(:simon) { Fabricate(:user, email: 'simon@example.com', account: Fabricate(:account, username: 'simon')).account }
-    let(:lewis) { Fabricate(:user, email: 'lewis@example.com', account: Fabricate(:account, username: 'lewis')).account }
+    let(:louis) { Fabricate(:user, email: 'louis@example.com', account: Fabricate(:account, username: 'louis')).account }
 
     before do
       user.account.follow!(simon)
-      lewis.follow!(user.account)
+      louis.follow!(user.account)
     end
 
     context 'provided only one ID' do
@@ -222,7 +222,7 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
 
     context 'provided multiple IDs' do
       before do
-        get :relationships, params: { id: [simon.id, lewis.id] }
+        get :relationships, params: { id: [simon.id, louis.id] }
       end
 
       it 'returns http success' do

--- a/spec/controllers/api/v1/blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/blocks_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::BlocksController, type: :controller do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'mus')) }
   let(:token) { double acceptable?: true, resource_owner_id: user.id }
 
   before do

--- a/spec/controllers/api/v1/favourites_controller_spec.rb
+++ b/spec/controllers/api/v1/favourites_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::FavouritesController, type: :controller do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'mus')) }
   let(:token) { double acceptable?: true, resource_owner_id: user.id }
 
   before do

--- a/spec/controllers/api/v1/follow_requests_controller_spec.rb
+++ b/spec/controllers/api/v1/follow_requests_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::FollowRequestsController, type: :controller do
   render_views
 
-  let(:user)     { Fabricate(:user, account: Fabricate(:account, username: 'alice', locked: true)) }
+  let(:user)     { Fabricate(:user, account: Fabricate(:account, username: 'mus', locked: true)) }
   let(:token)    { double acceptable?: true, resource_owner_id: user.id }
   let(:follower) { Fabricate(:account, username: 'bob') }
 

--- a/spec/controllers/api/v1/follows_controller_spec.rb
+++ b/spec/controllers/api/v1/follows_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::FollowsController, type: :controller do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'mus')) }
   let(:token) { double acceptable?: true, resource_owner_id: user.id }
 
   before do

--- a/spec/controllers/api/v1/media_controller_spec.rb
+++ b/spec/controllers/api/v1/media_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::MediaController, type: :controller do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'mus')) }
   let(:token) { double acceptable?: true, resource_owner_id: user.id }
 
   before do

--- a/spec/controllers/api/v1/mutes_controller_spec.rb
+++ b/spec/controllers/api/v1/mutes_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::MutesController, type: :controller do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'mus')) }
   let(:token) { double acceptable?: true, resource_owner_id: user.id }
 
   before do

--- a/spec/controllers/api/v1/notifications_controller_spec.rb
+++ b/spec/controllers/api/v1/notifications_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::NotificationsController, type: :controller do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'mus')) }
   let(:token) { double acceptable?: true, resource_owner_id: user.id }
   let(:other) { Fabricate(:user, account: Fabricate(:account, username: 'bob')) }
 
@@ -13,12 +13,12 @@ RSpec.describe Api::V1::NotificationsController, type: :controller do
 
   describe 'GET #index' do
     before do
-      first_status = PostStatusService.new.call(user.account, 'Test')
+      first_status = PostStatusService.new.call(user.account, 'Tst')
       @reblog_of_first_status = ReblogService.new.call(other.account, first_status)
-      mentioning_status = PostStatusService.new.call(other.account, 'Hello @alice')
+      mentioning_status = PostStatusService.new.call(other.account, 'Hallo @mus')
       @mention_from_status = mentioning_status.mentions.first
       @favourite = FavouriteService.new.call(other.account, first_status)
-      @follow = FollowService.new.call(other.account, 'alice')
+      @follow = FollowService.new.call(other.account, 'mus')
     end
 
     describe 'with no options' do

--- a/spec/controllers/api/v1/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::StatusesController, type: :controller do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'mus')) }
   let(:app)   { Fabricate(:application, name: 'Test app', website: 'http://testapp.com') }
   let(:token) { double acceptable?: true, resource_owner_id: user.id, application: app }
 
@@ -61,7 +61,7 @@ RSpec.describe Api::V1::StatusesController, type: :controller do
 
   describe 'POST #create' do
     before do
-      post :create, params: { status: 'Hello world' }
+      post :create, params: { status: 'Hallo world', spoiler_text: '' }
     end
 
     it 'returns http success' do

--- a/spec/controllers/api/v1/timelines_controller_spec.rb
+++ b/spec/controllers/api/v1/timelines_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::TimelinesController, type: :controller do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'mus')) }
 
   before do
     allow(controller).to receive(:doorkeeper_token) { token }
@@ -28,7 +28,7 @@ RSpec.describe Api::V1::TimelinesController, type: :controller do
 
     describe 'GET #tag' do
       before do
-        PostStatusService.new.call(user.account, 'It is a #test')
+        PostStatusService.new.call(user.account, 'It is a #trial')
       end
 
       it 'returns http success' do

--- a/spec/controllers/auth/registrations_controller_spec.rb
+++ b/spec/controllers/auth/registrations_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Auth::RegistrationsController, type: :controller do
     before do
       Setting.open_registrations = true
       request.env["devise.mapping"] = Devise.mappings[:user]
-      post :create, params: { user: { account_attributes: { username: 'test' }, email: 'test@example.com', password: '12345678', password_confirmation: '12345678' } }
+      post :create, params: { user: { account_attributes: { username: 'tst' }, email: 'test@example.com', password: '12345678', password_confirmation: '12345678' } }
     end
 
     it 'redirects to login page' do

--- a/spec/controllers/stream_entries_controller_spec.rb
+++ b/spec/controllers/stream_entries_controller_spec.rb
@@ -3,24 +3,24 @@ require 'rails_helper'
 RSpec.describe StreamEntriesController, type: :controller do
   render_views
 
-  let(:alice)  { Fabricate(:account, username: 'alice') }
-  let(:status) { Fabricate(:status, account: alice) }
+  let(:mus)  { Fabricate(:account, username: 'mus') }
+  let(:status) { Fabricate(:status, account: mus) }
 
   describe 'GET #show' do
     it 'returns http success with HTML' do
-      get :show, params: { account_username: alice.username, id: status.stream_entry.id }
+      get :show, params: { account_username: mus.username, id: status.stream_entry.id }
       expect(response).to have_http_status(:success)
     end
 
     it 'returns http success with Atom' do
-      get :show, params: { account_username: alice.username, id: status.stream_entry.id }, format: 'atom'
+      get :show, params: { account_username: mus.username, id: status.stream_entry.id }, format: 'atom'
       expect(response).to have_http_status(:success)
     end
   end
 
   describe 'GET #embed' do
     it 'returns embedded view of status' do
-      get :embed, params: { account_username: alice.username, id: status.stream_entry.id }
+      get :embed, params: { account_username: mus.username, id: status.stream_entry.id }
 
       expect(response).to have_http_status(:success)
       expect(response.headers['X-Frame-Options']).to eq 'ALLOWALL'

--- a/spec/controllers/xrd_controller_spec.rb
+++ b/spec/controllers/xrd_controller_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe XrdController, type: :controller do
   end
 
   describe 'GET #webfinger' do
-    let(:alice) { Fabricate(:account, username: 'alice') }
+    let(:mus) { Fabricate(:account, username: 'mus') }
 
     it 'returns http success when account can be found' do
-      get :webfinger, params: { resource: alice.to_webfinger_s }, format: :json
+      get :webfinger, params: { resource: mus.to_webfinger_s }, format: :json
       expect(response).to have_http_status(:success)
     end
 

--- a/spec/fabricators/account_fabricator.rb
+++ b/spec/fabricators/account_fabricator.rb
@@ -1,3 +1,3 @@
 Fabricator(:account) do
-  username { Faker::Internet.user_name(nil, %w(_)) }
+  username { Faker::Internet.user_name(nil, %w(_)).gsub('e', '') }
 end

--- a/spec/fabricators/status_fabricator.rb
+++ b/spec/fabricators/status_fabricator.rb
@@ -1,4 +1,4 @@
 Fabricator(:status) do
   account
-  text "Lorem ipsum dolor sit amet"
+  text "Lorm ipsum dolor sit amt"
 end

--- a/spec/lib/feed_manager_spec.rb
+++ b/spec/lib/feed_manager_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe FeedManager do
   end
 
   describe '#filter?' do
-    let(:followee) { Fabricate(:account, username: 'alice') }
+    let(:followee) { Fabricate(:account, username: 'mus') }
     let(:status)   { Fabricate(:status, text: 'Hello world', account: followee) }
     let(:follower) { Fabricate(:account, username: 'bob') }
 

--- a/spec/lib/formatter_spec.rb
+++ b/spec/lib/formatter_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Formatter do
-  let(:account)       { Fabricate(:account, username: 'alice') }
+  let(:account)       { Fabricate(:account, username: 'mus') }
   let(:local_status)  { Fabricate(:status, text: 'Hello world http://google.com', account: account) }
   let(:remote_status) { Fabricate(:status, text: '<script>alert("Hello")</script> Beep boop', uri: 'beepboop', account: account) }
 

--- a/spec/lib/tag_manager_spec.rb
+++ b/spec/lib/tag_manager_spec.rb
@@ -26,14 +26,14 @@ RSpec.describe TagManager do
   end
 
   describe '#uri_for' do
-    let(:alice)  { Fabricate(:account, username: 'alice') }
+    let(:mus)  { Fabricate(:account, username: 'mus') }
     let(:bob)    { Fabricate(:account, username: 'bob') }
-    let(:status) { Fabricate(:status, text: 'Hello world', account: alice) }
+    let(:status) { Fabricate(:status, text: 'Hello world', account: mus) }
 
     subject { TagManager.instance.uri_for(target) }
 
     context 'Account' do
-      let(:target) { alice }
+      let(:target) { mus }
 
       it 'returns a string' do
         expect(subject).to be_a String
@@ -50,14 +50,14 @@ RSpec.describe TagManager do
   end
 
   describe '#url_for' do
-    let(:alice)  { Fabricate(:account, username: 'alice') }
+    let(:mus)  { Fabricate(:account, username: 'mus') }
     let(:bob)    { Fabricate(:account, username: 'bob') }
-    let(:status) { Fabricate(:status, text: 'Hello world', account: alice) }
+    let(:status) { Fabricate(:status, text: 'Hello world', account: mus) }
 
     subject { TagManager.instance.url_for(target) }
 
     context 'Account' do
-      let(:target) { alice }
+      let(:target) { mus }
 
       it 'returns a URL' do
         expect(subject).to be_a String

--- a/spec/lib/webfinger_resource_spec.rb
+++ b/spec/lib/webfinger_resource_spec.rb
@@ -4,7 +4,7 @@ describe WebfingerResource do
   describe '#username' do
     describe 'with a URL value' do
       it 'raises with an unrecognized route' do
-        resource = 'https://example.com/users/alice/other'
+        resource = 'https://example.com/users/mus/other'
 
         expect {
           WebfingerResource.new(resource).username
@@ -12,7 +12,7 @@ describe WebfingerResource do
       end
 
       it 'raises with a string that doesnt start with URL' do
-        resource = 'website for http://example.com/users/alice/other'
+        resource = 'website for http://example.com/users/mus/other'
 
         expect {
           WebfingerResource.new(resource).username
@@ -20,24 +20,24 @@ describe WebfingerResource do
       end
 
       it 'finds the username in a valid https route' do
-        resource = 'https://example.com/users/alice'
+        resource = 'https://example.com/users/mus'
 
         result = WebfingerResource.new(resource).username
-        expect(result).to eq 'alice'
+        expect(result).to eq 'mus'
       end
 
       it 'finds the username in a mixed case http route' do
-        resource = 'HTTp://exAMPLEe.com/users/alice'
+        resource = 'HTTp://exAMPLEe.com/users/mus'
 
         result = WebfingerResource.new(resource).username
-        expect(result).to eq 'alice'
+        expect(result).to eq 'mus'
       end
 
       it 'finds the username in a valid http route' do
-        resource = 'http://example.com/users/alice'
+        resource = 'http://example.com/users/mus'
 
         result = WebfingerResource.new(resource).username
-        expect(result).to eq 'alice'
+        expect(result).to eq 'mus'
       end
     end
 
@@ -52,10 +52,10 @@ describe WebfingerResource do
 
       it 'finds username for a local domain' do
         Rails.configuration.x.local_domain = 'example.com'
-        resource = 'alice@example.com'
+        resource = 'mus@example.com'
 
         result = WebfingerResource.new(resource).username
-        expect(result).to eq 'alice'
+        expect(result).to eq 'mus'
       end
     end
 
@@ -78,10 +78,10 @@ describe WebfingerResource do
 
       it 'finds the username for a local account' do
         Rails.configuration.x.local_domain = 'example.com'
-        resource = 'acct:alice@example.com'
+        resource = 'acct:mus@example.com'
 
         result = WebfingerResource.new(resource).username
-        expect(result).to eq 'alice'
+        expect(result).to eq 'mus'
       end
     end
   end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe NotificationMailer, type: :mailer do
-  let(:receiver)       { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:receiver)       { Fabricate(:user, account: Fabricate(:account, username: 'mus')) }
   let(:sender)         { Fabricate(:account, username: 'bob') }
   let(:foreign_status) { Fabricate(:status, account: sender) }
   let(:own_status)     { Fabricate(:status, account: receiver.account) }
@@ -11,12 +11,12 @@ RSpec.describe NotificationMailer, type: :mailer do
     let(:mail) { NotificationMailer.mention(receiver.account, Notification.create!(account: receiver.account, activity: mention)) }
 
     it "renders the headers" do
-      expect(mail.subject).to eq("You were mentioned by bob")
+      expect(mail.subject).to eq("You got a tag from bob")
       expect(mail.to).to eq([receiver.email])
     end
 
     it "renders the body" do
-      expect(mail.body.encoded).to match("You were mentioned by bob")
+      expect(mail.body.encoded).to match("You got a tag by bob in")
     end
   end
 
@@ -39,12 +39,12 @@ RSpec.describe NotificationMailer, type: :mailer do
     let(:mail) { NotificationMailer.favourite(own_status.account, Notification.create!(account: receiver.account, activity: favourite)) }
 
     it "renders the headers" do
-      expect(mail.subject).to eq("bob favourited your status")
+      expect(mail.subject).to eq("bob put a star on your status")
       expect(mail.to).to eq([receiver.email])
     end
 
     it "renders the body" do
-      expect(mail.body.encoded).to match("Your status was favourited by bob")
+      expect(mail.body.encoded).to match("Your status got a star from bob")
     end
   end
 
@@ -53,12 +53,12 @@ RSpec.describe NotificationMailer, type: :mailer do
     let(:mail) { NotificationMailer.reblog(own_status.account, Notification.create!(account: receiver.account, activity: reblog)) }
 
     it "renders the headers" do
-      expect(mail.subject).to eq("bob boosted your status")
+      expect(mail.subject).to eq("Your status got a boost from bob")
       expect(mail.to).to eq([receiver.email])
     end
 
     it "renders the body" do
-      expect(mail.body.encoded).to match("Your status was boosted by bob")
+      expect(mail.body.encoded).to match("Your status got a boost from bob")
     end
   end
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Account, type: :model do
-  subject { Fabricate(:account, username: 'alice') }
+  subject { Fabricate(:account, username: 'mus') }
 
   context do
     let(:bob) { Fabricate(:account, username: 'bob') }
@@ -65,7 +65,7 @@ RSpec.describe Account, type: :model do
       it 'returns a webfinger string for the account' do
         Rails.configuration.x.local_domain = 'example.com'
 
-        expect(subject.to_webfinger_s).to eq 'acct:alice@example.com'
+        expect(subject.to_webfinger_s).to eq 'acct:mus@example.com'
       end
     end
 
@@ -73,19 +73,19 @@ RSpec.describe Account, type: :model do
       it 'returns the username and local domain for the account' do
         Rails.configuration.x.local_domain = 'example.com'
 
-        expect(subject.local_username_and_domain).to eq 'alice@example.com'
+        expect(subject.local_username_and_domain).to eq 'mus@example.com'
       end
     end
   end
 
   describe '#acct' do
     it 'returns username for local users' do
-      expect(subject.acct).to eql 'alice'
+      expect(subject.acct).to eql 'mus'
     end
 
     it 'returns username@domain for foreign users' do
       subject.domain = 'foreign.tld'
-      expect(subject.acct).to eql 'alice@foreign.tld'
+      expect(subject.acct).to eql 'mus@foreign.tld'
     end
   end
 
@@ -130,7 +130,7 @@ RSpec.describe Account, type: :model do
 
     context 'when the status is a reblog of another status' do
       let(:original_reblog) do
-        author = Fabricate(:account, username: 'original_reblogger')
+        author = Fabricate(:account, username: 'original_rbloggr')
         Fabricate(:status, reblog: original_status, account: author)
       end
 
@@ -166,7 +166,7 @@ RSpec.describe Account, type: :model do
 
     context 'when the status is a reblog of another status'do
       let(:original_reblog) do
-        author = Fabricate(:account, username: 'original_reblogger')
+        author = Fabricate(:account, username: 'original_rbloggr')
         Fabricate(:status, reblog: original_status, account: author)
       end
 
@@ -198,8 +198,8 @@ RSpec.describe Account, type: :model do
     before do
       @match = Fabricate(
         :account,
-        display_name: "Display Name",
-        username: "username",
+        display_name: "Display",
+        username: "usrnam",
         domain: "example.com"
       )
       _missing = Fabricate(
@@ -216,7 +216,7 @@ RSpec.describe Account, type: :model do
     end
 
     it 'finds accounts with matching username' do
-      results = Account.search_for("username")
+      results = Account.search_for("usrnam")
       expect(results).to eq [@match]
     end
 
@@ -228,10 +228,10 @@ RSpec.describe Account, type: :model do
     it 'ranks multiple matches higher' do
       account = Fabricate(
         :account,
-        username: "username",
-        display_name: "username"
+        username: "usrnam",
+        display_name: "usrnam"
       )
-      results = Account.search_for("username")
+      results = Account.search_for("usrnam")
       expect(results).to eq [account, @match]
     end
   end
@@ -240,7 +240,7 @@ RSpec.describe Account, type: :model do
     it 'ranks followed accounts higher' do
       account = Fabricate(:account)
       match = Fabricate(:account, username: "Matching")
-      followed_match = Fabricate(:account, username: "Matcher")
+      followed_match = Fabricate(:account, username: "Matchr")
       Fabricate(:follow, account: account, target_account: followed_match)
 
       results = Account.advanced_search_for("match", account)
@@ -251,15 +251,15 @@ RSpec.describe Account, type: :model do
 
   describe '.find_local' do
     before do
-      Fabricate(:account, username: 'Alice')
+      Fabricate(:account, username: 'mus')
     end
 
-    it 'returns Alice for alice' do
-      expect(Account.find_local('alice')).to_not be_nil
+    it 'returns mus for mus' do
+      expect(Account.find_local('mus')).to_not be_nil
     end
 
-    it 'returns Alice for Alice' do
-      expect(Account.find_local('Alice')).to_not be_nil
+    it 'returns mus for mus' do
+      expect(Account.find_local('mus')).to_not be_nil
     end
 
     it 'does not return anything for a_ice' do
@@ -273,27 +273,27 @@ RSpec.describe Account, type: :model do
 
   describe '.find_remote' do
     before do
-      Fabricate(:account, username: 'Alice', domain: 'mastodon.social')
+      Fabricate(:account, username: 'mus', domain: 'mastodon.social')
     end
 
-    it 'returns Alice for alice@mastodon.social' do
-      expect(Account.find_remote('alice', 'mastodon.social')).to_not be_nil
+    it 'returns mus for mus@mastodon.social' do
+      expect(Account.find_remote('mus', 'mastodon.social')).to_not be_nil
     end
 
-    it 'returns Alice for ALICE@MASTODON.SOCIAL' do
-      expect(Account.find_remote('ALICE', 'MASTODON.SOCIAL')).to_not be_nil
+    it 'returns mus for mus@MASTODON.SOCIAL' do
+      expect(Account.find_remote('mus', 'MASTODON.SOCIAL')).to_not be_nil
     end
 
     it 'does not return anything for a_ice@mastodon.social' do
       expect(Account.find_remote('a_ice', 'mastodon.social')).to be_nil
     end
 
-    it 'does not return anything for alice@m_stodon.social' do
-      expect(Account.find_remote('alice', 'm_stodon.social')).to be_nil
+    it 'does not return anything for mus@m_stodon.social' do
+      expect(Account.find_remote('mus', 'm_stodon.social')).to be_nil
     end
 
-    it 'does not return anything for alice@m%' do
-      expect(Account.find_remote('alice', 'm%')).to be_nil
+    it 'does not return anything for mus@m%' do
+      expect(Account.find_remote('mus', 'm%')).to be_nil
     end
   end
 
@@ -325,31 +325,31 @@ RSpec.describe Account, type: :model do
     subject { Account::MENTION_RE }
 
     it 'matches usernames in the middle of a sentence' do
-      expect(subject.match('Hello to @alice from me')[1]).to eq 'alice'
+      expect(subject.match('Hello to @mus from me')[1]).to eq 'mus'
     end
 
     it 'matches usernames in the beginning of status' do
-      expect(subject.match('@alice Hey how are you?')[1]).to eq 'alice'
+      expect(subject.match('@mus Hey how are you?')[1]).to eq 'mus'
     end
 
     it 'matches full usernames' do
-      expect(subject.match('@alice@example.com')[1]).to eq 'alice@example.com'
+      expect(subject.match('@mus@example.com')[1]).to eq 'mus@example.com'
     end
 
     it 'matches full usernames with a dot at the end' do
-      expect(subject.match('Hello @alice@example.com.')[1]).to eq 'alice@example.com'
+      expect(subject.match('Hello @mus@example.com.')[1]).to eq 'mus@example.com'
     end
 
     it 'matches dot-prepended usernames' do
-      expect(subject.match('.@alice I want everybody to see this')[1]).to eq 'alice'
+      expect(subject.match('.@mus I want everybody to see this')[1]).to eq 'mus'
     end
 
     it 'does not match e-mails' do
-      expect(subject.match('Drop me an e-mail at alice@example.com')).to be_nil
+      expect(subject.match('Drop me an e-mail at mus@example.com')).to be_nil
     end
 
     it 'does not match URLs' do
-      expect(subject.match('Check this out https://medium.com/@alice/some-article#.abcdef123')).to be_nil
+      expect(subject.match('Check this out https://medium.com/@mus/some-article#.abcdef123')).to be_nil
     end
   end
 
@@ -367,15 +367,15 @@ RSpec.describe Account, type: :model do
     end
 
     it 'is invalid if the username already exists' do
-      account_1 = Fabricate(:account, username: 'the_doctor')
-      account_2 = Fabricate.build(:account, username: 'the_doctor')
+      account_1 = Fabricate(:account, username: 'th_doctor')
+      account_2 = Fabricate.build(:account, username: 'th_doctor')
       account_2.valid?
       expect(account_2).to model_have_error_on_field(:username)
     end
 
     context 'when is local' do
       it 'is invalid if the username doesn\'t only contains letters, numbers and underscores' do
-        account = Fabricate.build(:account, username: 'the-doctor')
+        account = Fabricate.build(:account, username: 'th-doctor')
         account.valid?
         expect(account).to model_have_error_on_field(:username)
       end

--- a/spec/models/favourite_spec.rb
+++ b/spec/models/favourite_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Favourite, type: :model do
-  let(:alice)  { Fabricate(:account, username: 'alice') }
+  let(:mus)  { Fabricate(:account, username: 'mus') }
   let(:bob)    { Fabricate(:account, username: 'bob') }
   let(:status) { Fabricate(:status, account: bob) }
 
-  subject { Favourite.new(account: alice, status: status) }
+  subject { Favourite.new(account: mus, status: status) }
 end

--- a/spec/models/follow_spec.rb
+++ b/spec/models/follow_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Follow, type: :model do
-  let(:alice) { Fabricate(:account, username: 'alice') }
+  let(:mus) { Fabricate(:account, username: 'mus') }
   let(:bob)   { Fabricate(:account, username: 'bob') }
 
-  subject { Follow.new(account: alice, target_account: bob) }
+  subject { Follow.new(account: mus, target_account: bob) }
 
   describe 'validations' do
     it 'has a valid fabricator' do

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Status, type: :model do
-  let(:alice) { Fabricate(:account, username: 'alice') }
+  let(:mus) { Fabricate(:account, username: 'mus') }
   let(:bob)   { Fabricate(:account, username: 'bob') }
   let(:other) { Fabricate(:status, account: bob, text: 'Skulls for the skull god! The enemy\'s gates are sideways!')}
 
-  subject { Fabricate(:status, account: alice) }
+  subject { Fabricate(:status, account: mus) }
 
   describe '#local?' do
     it 'returns true when no remote URI is set' do
@@ -93,7 +93,7 @@ RSpec.describe Status, type: :model do
   describe '#reblogs_count' do
     it 'is the number of reblogs' do
       Fabricate(:status, account: bob, reblog: subject)
-      Fabricate(:status, account: alice, reblog: subject)
+      Fabricate(:status, account: mus, reblog: subject)
 
       expect(subject.reblogs_count).to eq 2
     end
@@ -102,7 +102,7 @@ RSpec.describe Status, type: :model do
   describe '#favourites_count' do
     it 'is the number of favorites' do
       Fabricate(:favourite, account: bob, status: subject)
-      Fabricate(:favourite, account: alice, status: subject)
+      Fabricate(:favourite, account: mus, status: subject)
 
       expect(subject.favourites_count).to eq 2
     end

--- a/spec/models/stream_entry_spec.rb
+++ b/spec/models/stream_entry_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe StreamEntry, type: :model do
-  let(:alice)     { Fabricate(:account, username: 'alice') }
+  let(:mus)     { Fabricate(:account, username: 'mus') }
   let(:bob)       { Fabricate(:account, username: 'bob') }
-  let(:status)    { Fabricate(:status, account: alice) }
+  let(:status)    { Fabricate(:status, account: mus) }
   let(:reblog)    { Fabricate(:status, account: bob, reblog: status) }
   let(:reply)     { Fabricate(:status, account: bob, thread: status) }
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Tag, type: :model do
     subject { Tag::HASHTAG_RE }
 
     it 'does not match URLs with anchors with non-hashtag characters' do
-      expect(subject.match('Check this out https://medium.com/@alice/some-article#.abcdef123')).to be_nil
+      expect(subject.match('Check this out https://medium.com/@mus/some-article#.abcdef123')).to be_nil
     end
 
     it 'does not match URLs with hashtag-like anchors' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe User, type: :model do
     end
   end
 
-  let(:account) { Fabricate(:account, username: 'alice') }
+  let(:account) { Fabricate(:account, username: 'mus') }
   let(:password) { 'abcd1234' }
 
   describe 'blacklist' do

--- a/spec/requests/webfinger_request_spec.rb
+++ b/spec/requests/webfinger_request_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
 describe "The webfinger route" do
-  let(:alice) { Fabricate(:account, username: 'alice') }
+  let(:mus) { Fabricate(:account, username: 'mus') }
 
   describe "requested without accepts headers" do
     it "returns a json response" do
-      get webfinger_url, params: { resource: alice.to_webfinger_s }
+      get webfinger_url, params: { resource: mus.to_webfinger_s }
 
       expect(response).to have_http_status(:success)
       expect(response.content_type).to eq "application/jrd+json"
@@ -15,7 +15,7 @@ describe "The webfinger route" do
   describe "requested with html in accepts headers" do
     it "returns a json response" do
       headers = { 'HTTP_ACCEPT' => 'text/html' }
-      get webfinger_url, params: { resource: alice.to_webfinger_s }, headers: headers
+      get webfinger_url, params: { resource: mus.to_webfinger_s }, headers: headers
 
       expect(response).to have_http_status(:success)
       expect(response.content_type).to eq "application/jrd+json"
@@ -24,7 +24,7 @@ describe "The webfinger route" do
 
   describe "requested with xml format" do
     it "returns an xml response" do
-      get webfinger_url(resource: alice.to_webfinger_s, format: :xml)
+      get webfinger_url(resource: mus.to_webfinger_s, format: :xml)
 
       expect(response).to have_http_status(:success)
       expect(response.content_type).to eq "application/xrd+xml"

--- a/spec/services/authorize_follow_service_spec.rb
+++ b/spec/services/authorize_follow_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe AuthorizeFollowService do
-  let(:sender) { Fabricate(:account, username: 'alice') }
+  let(:sender) { Fabricate(:account, username: 'mus') }
 
   subject { AuthorizeFollowService.new }
 

--- a/spec/services/block_service_spec.rb
+++ b/spec/services/block_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe BlockService do
-  let(:sender) { Fabricate(:account, username: 'alice') }
+  let(:sender) { Fabricate(:account, username: 'mus') }
 
   subject { BlockService.new }
 

--- a/spec/services/fan_out_on_write_service_spec.rb
+++ b/spec/services/fan_out_on_write_service_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 RSpec.describe FanOutOnWriteService do
   let(:author)   { Fabricate(:account, username: 'tom') }
-  let(:status)   { Fabricate(:status, text: 'Hello @alice #test', account: author) }
-  let(:alice)    { Fabricate(:user, account: Fabricate(:account, username: 'alice')).account }
+  let(:status)   { Fabricate(:status, text: 'Hello @mus #test', account: author) }
+  let(:mus)    { Fabricate(:user, account: Fabricate(:account, username: 'mus')).account }
   let(:follower) { Fabricate(:account, username: 'bob') }
 
   subject { FanOutOnWriteService.new }
 
   before do
-    alice
+    mus
     follower.follow!(author)
 
     ProcessMentionsService.new.call(status)
@@ -32,6 +32,6 @@ RSpec.describe FanOutOnWriteService do
   end
 
   it 'delivers status to public timeline' do
-    expect(Status.as_public_timeline(alice).map(&:id)).to include status.id
+    expect(Status.as_public_timeline(mus).map(&:id)).to include status.id
   end
 end

--- a/spec/services/favourite_service_spec.rb
+++ b/spec/services/favourite_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe FavouriteService do
-  let(:sender) { Fabricate(:account, username: 'alice') }
+  let(:sender) { Fabricate(:account, username: 'mus') }
 
   subject { FavouriteService.new }
 

--- a/spec/services/follow_service_spec.rb
+++ b/spec/services/follow_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe FollowService do
-  let(:sender) { Fabricate(:account, username: 'alice') }
+  let(:sender) { Fabricate(:account, username: 'mus') }
 
   subject { FollowService.new }
 

--- a/spec/services/post_status_service_spec.rb
+++ b/spec/services/post_status_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe PostStatusService do
 
   it 'creates a new status' do
     account = Fabricate(:account)
-    text = "test status update"
+    text = "tst status updat"
 
     status = subject.call(account, text)
 
@@ -16,7 +16,7 @@ RSpec.describe PostStatusService do
   it 'creates a new response status' do
     in_reply_to_status = Fabricate(:status)
     account = Fabricate(:account)
-    text = "test status update"
+    text = "tst status updat"
 
     status = subject.call(account, text, in_reply_to_status)
 
@@ -33,7 +33,7 @@ RSpec.describe PostStatusService do
   end
 
   it 'creates a status with spoiler text' do
-    spoiler_text = "spoiler text"
+    spoiler_text = "spoilr txt"
 
     status = create_status_with_options(spoiler_text: spoiler_text)
 
@@ -70,7 +70,7 @@ RSpec.describe PostStatusService do
     allow(ProcessMentionsService).to receive(:new).and_return(mention_service)
     account = Fabricate(:account)
 
-    status = subject.call(account, "test status update")
+    status = subject.call(account, "tst status updat")
 
     expect(ProcessMentionsService).to have_received(:new)
     expect(mention_service).to have_received(:call).with(status)
@@ -82,7 +82,7 @@ RSpec.describe PostStatusService do
     allow(ProcessHashtagsService).to receive(:new).and_return(hashtags_service)
     account = Fabricate(:account)
 
-    status = subject.call(account, "test status update")
+    status = subject.call(account, "tst status updat")
 
     expect(ProcessHashtagsService).to have_received(:new)
     expect(hashtags_service).to have_received(:call).with(status)
@@ -93,7 +93,7 @@ RSpec.describe PostStatusService do
     allow(Pubsubhubbub::DistributionWorker).to receive(:perform_async)
     account = Fabricate(:account)
 
-    status = subject.call(account, "test status update")
+    status = subject.call(account, "tst status updat")
 
     expect(DistributionWorker).to have_received(:perform_async).with(status.id)
     expect(Pubsubhubbub::DistributionWorker).
@@ -104,7 +104,7 @@ RSpec.describe PostStatusService do
     allow(LinkCrawlWorker).to receive(:perform_async)
     account = Fabricate(:account)
 
-    status = subject.call(account, "test status update")
+    status = subject.call(account, "tst status updat")
 
     expect(LinkCrawlWorker).to have_received(:perform_async).with(status.id)
   end
@@ -115,7 +115,7 @@ RSpec.describe PostStatusService do
 
     status = subject.call(
       account,
-      "test status update",
+      "tst status updat",
       nil,
       media_ids: [media.id],
     )
@@ -129,7 +129,7 @@ RSpec.describe PostStatusService do
     expect do
       subject.call(
         account,
-        "test status update",
+        "tst status updat",
         nil,
         media_ids: [
           Fabricate(:media_attachment, account: account),
@@ -151,7 +151,7 @@ RSpec.describe PostStatusService do
     expect do
       subject.call(
         account,
-        "test status update",
+        "tst status updat",
         nil,
         media_ids: [
           Fabricate(:media_attachment, type: :video, account: account),
@@ -165,6 +165,6 @@ RSpec.describe PostStatusService do
   end
 
   def create_status_with_options(options = {})
-    subject.call(Fabricate(:account), "test", nil, options)
+    subject.call(Fabricate(:account), "tst", nil, options)
   end
 end

--- a/spec/services/process_interaction_service_spec.rb
+++ b/spec/services/process_interaction_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ProcessInteractionService do
-  let(:receiver) { Fabricate(:user, email: 'alice@example.com', account: Fabricate(:account, username: 'alice')).account }
+  let(:receiver) { Fabricate(:user, email: 'mus@example.com', account: Fabricate(:account, username: 'mus')).account }
   let(:sender)   { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
 
   subject { ProcessInteractionService.new }
@@ -39,8 +39,8 @@ XML
       payload = <<XML
 <entry xmlns="http://www.w3.org/2005/Atom" xmlns:activity="http://activitystrea.ms/spec/1.0/">
   <author>
-    <name>alice</name>
-    <uri>https://cb6e6126.ngrok.io/users/alice</uri>
+    <name>mus</name>
+    <uri>https://cb6e6126.ngrok.io/users/mus</uri>
   </author>
 
   <id>someIdHere</id>
@@ -69,8 +69,8 @@ XML
       payload = <<XML
 <entry xmlns="http://www.w3.org/2005/Atom" xmlns:activity="http://activitystrea.ms/spec/1.0/">
   <author>
-    <name>alice</name>
-    <uri>https://cb6e6126.ngrok.io/users/alice</uri>
+    <name>mus</name>
+    <uri>https://cb6e6126.ngrok.io/users/mus</uri>
   </author>
 
   <id>someIdHere</id>

--- a/spec/services/process_mentions_service_spec.rb
+++ b/spec/services/process_mentions_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ProcessMentionsService do
-  let(:account)     { Fabricate(:account, username: 'alice') }
+  let(:account)     { Fabricate(:account, username: 'mus') }
   let(:remote_user) { Fabricate(:account, username: 'remote_user', domain: 'example.com', salmon_url: 'http://salmon.example.com') }
   let(:status)      { Fabricate(:status, account: account, text: "Hello @#{remote_user.acct}") }
 

--- a/spec/services/reblog_service_spec.rb
+++ b/spec/services/reblog_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ReblogService do
-  let(:alice)  { Fabricate(:account, username: 'alice') }
+  let(:mus)  { Fabricate(:account, username: 'mus') }
   let(:bob)    { Fabricate(:account, username: 'bob', domain: 'example.com', salmon_url: 'http://salmon.example.com') }
   let(:status) { Fabricate(:status, account: bob, uri: 'tag:example.com;something:something') }
 
@@ -10,7 +10,7 @@ RSpec.describe ReblogService do
   before do
     stub_request(:post, 'http://salmon.example.com')
 
-    subject.(alice, status)
+    subject.(mus, status)
   end
 
   it 'creates a reblog' do

--- a/spec/services/reject_follow_service_spec.rb
+++ b/spec/services/reject_follow_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe RejectFollowService do
-  let(:sender) { Fabricate(:account, username: 'alice') }
+  let(:sender) { Fabricate(:account, username: 'mus') }
 
   subject { RejectFollowService.new }
 

--- a/spec/services/unblock_service_spec.rb
+++ b/spec/services/unblock_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe UnblockService do
-  let(:sender) { Fabricate(:account, username: 'alice') }
+  let(:sender) { Fabricate(:account, username: 'mus') }
 
   subject { UnblockService.new }
 

--- a/spec/services/unfollow_service_spec.rb
+++ b/spec/services/unfollow_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe UnfollowService do
-  let(:sender) { Fabricate(:account, username: 'alice') }
+  let(:sender) { Fabricate(:account, username: 'mus') }
 
   subject { UnfollowService.new }
 


### PR DESCRIPTION
PR for discussion. 

Mastodon's automatic trials all cook up an account with display alias `"alic*"`. Status trials all cook up a status with `"Lor*m Ipsum"` in its body. I'd want to know our PRs won't go causing goofs, but this might also start crazy git conflicts. Your thoughts, y'all?